### PR TITLE
Migration to cats-effects 3 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,9 +41,6 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
   .jsSettings(
     scalaJSStage in Global := FastOptStage
   )
-//
-//ThisBuild / scalacOptions += "-P:semanticdb:synthetics:on"
-//
 
 lazy val buildSettings = sharedBuildSettings(gh, libs)
 

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ val mainDev =
     new java.net.URL("http://github.com/kailuowang")
   )
 
-lazy val libs = org.typelevel.libraries
+lazy val libs = org.typelevel.libraries.add("cats-effect", "3.1.1")
 
 lazy val mau = project
   .in(file("."))
@@ -36,17 +36,20 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
     rootSettings,
     libs.dependencies("cats-effect"),
     libs.testDependencies("scalatest"),
-    scalacOptions in Test --= Seq("-Xlint:-unused,_", "-Ywarn-unused:imports")
+    Test / scalacOptions --= Seq("-Xlint:-unused,_", "-Ywarn-unused:imports")
   )
   .jsSettings(
     scalaJSStage in Global := FastOptStage
   )
+//
+//ThisBuild / scalacOptions += "-P:semanticdb:synthetics:on"
+//
 
 lazy val buildSettings = sharedBuildSettings(gh, libs)
 
 lazy val commonSettings = addCompilerPlugins(libs, "kind-projector") ++ sharedCommonSettings ++ Seq(
   organization := "com.kailuowang",
-  parallelExecution in Test := false,
+  Test / parallelExecution := false,
   scalaVersion := libs.vers("scalac_2.13"),
   crossScalaVersions := Seq(
     scalaVersion.value,

--- a/core/src/main/scala/mau/Repeating.scala
+++ b/core/src/main/scala/mau/Repeating.scala
@@ -1,7 +1,6 @@
 package mau
 
-import cats.effect.concurrent.{Deferred, Ref}
-import cats.effect.{Concurrent, Fiber, Resource, Timer}
+import cats.effect.{Concurrent, Deferred, Fiber, Ref, Resource, Temporal}
 import cats.implicits._
 
 import scala.concurrent.duration.FiniteDuration
@@ -33,10 +32,10 @@ object Repeating {
       repeatDuration: FiniteDuration,
       runInParallel: Boolean
     )(implicit F: Concurrent[F],
-      T: Timer[F]
+      T: Temporal[F]
     ): F[Repeating[F]] = {
     Ref[F]
-      .of(none[Fiber[F, Unit]])
+      .of(none[Fiber[F, Throwable, Unit]])
       .map { ref =>
         new Repeating[F] {
           def pause: F[Boolean] =
@@ -81,7 +80,7 @@ object Repeating {
     *                      the effect.
     *
     */
-  def resource[F[_]: Concurrent: Timer](
+  def resource[F[_]: Temporal](
       effect: F[Unit],
       repeatDuration: FiniteDuration,
       runInParallel: Boolean

--- a/core/src/test/scala/mau/tests/RefreshRefSuite.scala
+++ b/core/src/test/scala/mau/tests/RefreshRefSuite.scala
@@ -1,13 +1,16 @@
 package mau
 package tests
 
-import cats.effect.{Concurrent, IO, Resource}
-import cats.effect.concurrent.Ref
+
+import cats.effect.{Concurrent, IO, Ref, Resource, Temporal}
+import cats.effect.unsafe.implicits.global
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.funsuite.AsyncFunSuite
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
+
 import cats.implicits._
 
 import scala.util.control.NoStackTrace
@@ -17,8 +20,7 @@ class RefreshRefSuite extends AsyncFunSuite with Matchers {
   implicit override def executionContext: ExecutionContext =
     ExecutionContext.global
 
-  implicit val ctx = IO.contextShift(executionContext)
-  implicit val timer = IO.timer(executionContext)
+  implicit val timer = Temporal[IO]
 
   def testWithRef[A](f: RefreshRef[IO, Int] => IO[A]): Future[A] =
     RefreshRef

--- a/core/src/test/scala/mau/tests/RepeatingSuite.scala
+++ b/core/src/test/scala/mau/tests/RepeatingSuite.scala
@@ -1,8 +1,9 @@
 package mau
 package tests
 
-import cats.effect.IO
-import cats.effect.concurrent.Ref
+import cats.effect.{IO, Temporal, Ref}
+import cats.effect.unsafe.implicits.global
+
 import org.scalatest.freespec.AsyncFreeSpec
 import org.scalatest.matchers.should.Matchers
 import cats.implicits._
@@ -15,8 +16,7 @@ class RepeatingSuite extends AsyncFreeSpec with Matchers {
   implicit override def executionContext: ExecutionContext =
     ExecutionContext.global
 
-  implicit val ctx = IO.contextShift(executionContext)
-  implicit val timer = IO.timer(executionContext)
+  implicit val timer = Temporal[IO]
 
   implicit def toFuture[A](ioA: IO[A]): Future[A] = ioA.unsafeToFuture()
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.3-SNAPSHOT"
+ThisBuild / version := "0.2.3-SNAPSHOT"


### PR DESCRIPTION
This is a pretty straightforward migration, mostly done by scalafix tool - after running it I only fixed minor things manually.

In addition to that, I did 2 minor things:
- renamed source file from RefeshRef to Ref**r**eshRef - typo I guess?
- fixed sbt syntax from deprecated `<param> in ThisBuikd` to current one - ` ThisBuild / <param> ` - I could roll it back, if you prefer it that way.